### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -232,3 +232,9 @@ variable "capacity_providers_ec2" {
     error_message = "'FARGATE' and 'FARGATE_SPOT' name is reserved"
   }
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "The name of a VPC component"
+  default     = "vpc"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variable `vpc_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to set the VPC component name, allowing users to customize this value as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->