### PR TITLE
Enhance variables.tf with new parameters

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -130,6 +130,7 @@ variable "capacity_providers_ec2" {
         delete_on_termination = bool
         encrypted             = bool
         iops                  = number
+        throughput            = number
         kms_key_id            = string
         snapshot_id           = string
         volume_size           = number
@@ -149,10 +150,12 @@ variable "capacity_providers_ec2" {
     instance_refresh = optional(object({
       strategy = string
       preferences = optional(object({
-        instance_warmup        = optional(number, null)
-        min_healthy_percentage = optional(number, null)
-        skip_matching          = optional(bool, null)
-        auto_rollback          = optional(bool, null)
+        instance_warmup              = optional(number, null)
+        min_healthy_percentage       = optional(number, null)
+        skip_matching                = optional(bool, null)
+        auto_rollback                = optional(bool, null)
+        scale_in_protected_instances = optional(string)
+        standby_instances            = optional(string)
       }), null)
       triggers = optional(list(string), [])
     }))


### PR DESCRIPTION
Added throughput and additional optional fields for instance refresh.

This pull request adds new configuration options to the `capacity_providers_ec2` variable in `src/variables.tf`, enhancing support for EC2 storage and scaling features.

**EC2 Storage Configuration Enhancements:**
* Added `throughput` parameter to support specifying EBS volume throughput for EC2 instances.

**EC2 Scaling and Protection Options:**
* Added `scale_in_protected_instances` and `standby_instances` parameters to allow configuration of protected and standby instances in EC2 capacity providers.

## References
 - https://github.com/cloudposse/terraform-aws-ecs-cluster/pull/62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support configuring EBS volume throughput for EC2 capacity providers.
  - Added optional instance refresh preferences: scale_in_protected_instances and standby_instances.

- Style
  - Formatting adjustments to existing instance refresh settings without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->