### PR TITLE
Add container insights mode variable with validation

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -73,7 +73,7 @@ module "cluster" {
 
   context = module.this.context
 
-  container_insights_enabled      = var.container_insights_enabled
+  container_insights_mode         = var.container_insights_mode
   capacity_providers_fargate      = var.capacity_providers_fargate
   capacity_providers_fargate_spot = var.capacity_providers_fargate_spot
   capacity_providers_ec2 = {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -57,10 +57,14 @@ variable "maintenance_page_path" {
   description = "The path from this directory to the text/html page to use as the maintenance page. Must be within 1024 characters"
 }
 
-variable "container_insights_enabled" {
-  type        = bool
-  default     = true
-  description = "Whether or not to enable container insights"
+variable "container_insights_mode" {
+  description = "Container insights mode. Valid values: 'enhanced', 'enabled', 'disabled'. NOTE: `enhanced` is more costly, but as described by AWS, it 'provides detailed health and performance metrics at task and container level in addition to aggregated metrics at cluster and service level. Enables easier drill downs for faster problem isolation and troubleshooting.' (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html)"
+  type        = string
+  default     = "enabled"
+  validation {
+    condition     = contains(["enhanced", "enabled", "disabled"], var.container_insights_mode)
+    error_message = "The 'container_insights_mode' value must be one of 'enhanced', 'enabled', 'disabled'"
+  }
 }
 
 variable "dns_delegated_stage_name" {


### PR DESCRIPTION
Added a new variable for container insights mode with validation.

## what
* Replace `container_insights_enabled` with `container_insights_mode`

## why
* `cloudposse/terraform-aws-ecs-cluster` `v2.0.0` replace `container_insights_enabled` with `container_insights_mode` input