### PR TITLE
Remove invalid capacity_reservation_specification arg from module "alb"

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -205,12 +205,12 @@ module "alb" {
   cross_zone_load_balancing_enabled = lookup(each.value, "cross_zone_load_balancing_enabled", true)
 
   # v2.x variables
-  client_keep_alive                  = lookup(each.value, "client_keep_alive", null)
-  https_ssl_policy                   = lookup(each.value, "https_ssl_policy", "ELBSecurityPolicy-TLS13-1-2-2021-06")
-  load_balancing_anomaly_mitigation  = lookup(each.value, "load_balancing_anomaly_mitigation", null)
-  http_ingress_security_group_ids  = lookup(each.value, "http_ingress_security_group_ids", [])
-  https_ingress_security_group_ids = lookup(each.value, "https_ingress_security_group_ids", [])
-  enable_waf_fail_open             = lookup(each.value, "enable_waf_fail_open", false)
+  client_keep_alive                 = lookup(each.value, "client_keep_alive", null)
+  https_ssl_policy                  = lookup(each.value, "https_ssl_policy", "ELBSecurityPolicy-TLS13-1-2-2021-06")
+  load_balancing_anomaly_mitigation = lookup(each.value, "load_balancing_anomaly_mitigation", null)
+  http_ingress_security_group_ids   = lookup(each.value, "http_ingress_security_group_ids", [])
+  https_ingress_security_group_ids  = lookup(each.value, "https_ingress_security_group_ids", [])
+  enable_waf_fail_open              = lookup(each.value, "enable_waf_fail_open", false)
 
   target_group_name        = join(module.target_group_label.delimiter, [module.target_group_label.id, each.key])
   target_group_port        = lookup(each.value, "target_group_port", 80)

--- a/src/main.tf
+++ b/src/main.tf
@@ -208,10 +208,9 @@ module "alb" {
   client_keep_alive                  = lookup(each.value, "client_keep_alive", null)
   https_ssl_policy                   = lookup(each.value, "https_ssl_policy", "ELBSecurityPolicy-TLS13-1-2-2021-06")
   load_balancing_anomaly_mitigation  = lookup(each.value, "load_balancing_anomaly_mitigation", null)
-  http_ingress_security_group_ids    = lookup(each.value, "http_ingress_security_group_ids", [])
-  https_ingress_security_group_ids   = lookup(each.value, "https_ingress_security_group_ids", [])
-  capacity_reservation_specification = lookup(each.value, "capacity_reservation_specification", null)
-  enable_waf_fail_open               = lookup(each.value, "enable_waf_fail_open", false)
+  http_ingress_security_group_ids  = lookup(each.value, "http_ingress_security_group_ids", [])
+  https_ingress_security_group_ids = lookup(each.value, "https_ingress_security_group_ids", [])
+  enable_waf_fail_open             = lookup(each.value, "enable_waf_fail_open", false)
 
   target_group_name        = join(module.target_group_label.delimiter, [module.target_group_label.id, each.key])
   target_group_port        = lookup(each.value, "target_group_port", 80)


### PR DESCRIPTION
## what

- Remove the line `capacity_reservation_specification = lookup(each.value, "capacity_reservation_specification", null)` from `module "alb"` in `src/main.tf`

## why

- `cloudposse/alb/aws` (at both the currently pinned v2.5.0 and the previously pinned v2.4.0) does **not** expose a `capacity_reservation_specification` variable. Its registry input list includes `reserved_capacity_units` but not `capacity_reservation_specification`
- As a result, `terraform plan` / `terraform apply` on this component fails with:

  ```
  Error: Unsupported argument

    on main.tf line 213, in module "alb":
   213:   capacity_reservation_specification = lookup(each.value, "capacity_reservation_specification", null)

  An argument named "capacity_reservation_specification" is not expected here.
  ```
- The argument was added in the alb v2.4.0 bump (#56) without a matching variable in the upstream alb module — a copy-paste miss

- Surfaced by a downstream `aws-ecs-service` test that deploys the `ecs-cluster` component as a dependency

## references

- Invalid-arg error in a downstream PR run: https://github.com/cloudposse-terraform-components/aws-ecs-service/actions/runs/24578145405/job/71868954601
- `cloudposse/alb/aws` v2.5.0 registry inputs: https://registry.terraform.io/v1/modules/cloudposse/alb/aws/2.5.0 (no `capacity_reservation_specification`)
- PR that introduced the argument: #56 (alb v2.4.0 bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code formatting and alignment in infrastructure configuration for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->