### PR TITLE
fix(alb): bump default https_ssl_policy to TLS13-1-3-2021-06

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -206,7 +206,7 @@ module "alb" {
 
   # v2.x variables
   client_keep_alive                 = lookup(each.value, "client_keep_alive", null)
-  https_ssl_policy                  = lookup(each.value, "https_ssl_policy", "ELBSecurityPolicy-TLS13-1-2-2021-06")
+  https_ssl_policy                  = lookup(each.value, "https_ssl_policy", "ELBSecurityPolicy-TLS13-1-3-2021-06")
   load_balancing_anomaly_mitigation = lookup(each.value, "load_balancing_anomaly_mitigation", null)
   http_ingress_security_group_ids   = lookup(each.value, "http_ingress_security_group_ids", [])
   https_ingress_security_group_ids  = lookup(each.value, "https_ingress_security_group_ids", [])


### PR DESCRIPTION
## Summary
- Update the default `https_ssl_policy` for the `alb` module from `ELBSecurityPolicy-TLS13-1-2-2021-06` to `ELBSecurityPolicy-TLS13-1-3-2021-06` to satisfy pentest requirements (TLS 1.3 only).
- Per-ALB override via the `https_ssl_policy` input still works.

## Compatibility
- `ELBSecurityPolicy-TLS13-1-3-2021-06` is TLS 1.3 only — clients without TLS 1.3 support will fail to connect. Consumers needing broader compatibility should override `https_ssl_policy` explicitly.

## Test plan
- [ ] `terraform validate` / `terraform plan` against an existing stack shows only the expected `ssl_policy` change on HTTPS listeners.
- [ ] Confirm downstream consumers either accept TLS 1.3 only or set `https_ssl_policy` to a less strict policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Updated the default HTTPS SSL/TLS security policy to a newer encryption standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->